### PR TITLE
Add widget._id to widget.wrapper

### DIFF
--- a/lib/modules/apostrophe-areas/views/widget.html
+++ b/lib/modules/apostrophe-areas/views/widget.html
@@ -2,7 +2,7 @@
 {# however ginormous joined objects are elided. Use APIs to #}
 {# get them if you need them (TODO: consider ways of #}
 {# whitelisting them for the inline JSON attributes) #}
-<div class="apos-area-widget-wrapper" data-apos-widget-wrapper="{{ data.widget.type }}">
+<div class="apos-area-widget-wrapper" data-apos-widget-wrapper="{{ data.widget.type }}" data-apos-widget-id="{{ data.widget._id }}">
   {# This wrapper exists for editor.js to inject contextual widget insertion controls into,
     since those are area level controls rather than widget level #}
   <div class="apos-area-widget{% if data.manager.options.contextualOnly %} apos-area-widget--contextual{% endif %}" data-apos-widget="{{ data.widget.type }}" data-apos-widget-id="{{ data.widget._id }}" data='{{ data.dataFiltered | jsonAttribute({ single: true }) }}' data-options='{{ data.manager.filterOptionsForDataAttribute(apos.utils.omit(data.options, 'area')) | jsonAttribute({ single: true }) }}'>


### PR DESCRIPTION
With the id we can create widgets for styling with css-flex-layout without using javascript for getting to the parent.